### PR TITLE
Improve gas usage for ERC20 approval

### DIFF
--- a/contracts/datamanagers/MinimalisticERC20FractionDataManager.sol
+++ b/contracts/datamanagers/MinimalisticERC20FractionDataManager.sol
@@ -225,7 +225,7 @@ contract MinimalisticERC20FractionDataManager is Initializable, IFractionTransfe
                 revert ERC20InsufficientAllowance(spender, currentAllowanceAmount, amount);
             }
             unchecked {
-                currentAllowance.amount = currentAllowanceAmount-amount;
+                currentAllowance.amount = currentAllowanceAmount - amount;
             }
         }
     }


### PR DESCRIPTION
Improves PR #32  which fixes issue  #22: removes one storage read (saving 107 gas units)
